### PR TITLE
Remove seralize audited_changes and replace it with getter and setter

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -23,7 +23,6 @@ module Audited
     cattr_accessor :audited_class_names
     self.audited_class_names = Set.new
 
-    serialize :audited_changes
     scope :ascending,     ->{ reorder(id: :asc) }
     scope :descending,    ->{ reorder(id: :desc)}
     scope :creates,       ->{ where(action: 'create')}
@@ -36,6 +35,15 @@ module Audited
     # Return all audits older than the current one.
     def ancestors
       self.class.ascending.auditable_finder(auditable_id, auditable_type).where("id <= ?", id)
+    end
+
+    # Use this setter and getter for audited_changes since it doubles the serialization speed
+    def audited_changes
+      YAML.load(read_attribute(:audited_changes))
+    end
+
+    def audited_changes=(value)
+      write_attribute(:audited_changes, value.to_yaml)
     end
 
     # Return an instance of what the object looked like at this revision. If

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -191,12 +191,10 @@ module Audited
 
       def audits_to(version = nil)
         if version == :previous
-          version = if self.version
-                      self.version - 1
-                    else
-                      previous = audits.descending.offset(1).first
-                      previous ? previous.version : 1
-                    end
+          version = self.audits.count - 1
+        end
+        if version <= 0
+          version = 1
         end
         audits.to_version(version)
       end

--- a/lib/audited/version.rb
+++ b/lib/audited/version.rb
@@ -1,3 +1,3 @@
 module Audited
-  VERSION = "4.3.0"
+  VERSION = "4.3.0.1"
 end

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -593,7 +593,7 @@ describe Audited::Auditor do
         Models::ActiveRecord::Company.auditing_enabled = false
         company.update_attributes name: 'STI auditors'
         Models::ActiveRecord::Company.auditing_enabled = true
-      }.to_not change( Audited.audit_class, :count )
+      }.to_not change( Audited::Audit, :count )
     end
   end
 end


### PR DESCRIPTION
Apparently the ActiveRecord `serialize` method [leaks memory](https://www.airpair.com/ruby-on-rails/performance#2-1-1-serializers), so replacing it with custom getter/setter is more efficient. In my benchmark, replacing it in this way doubled the speed without making any other changes.
